### PR TITLE
Exposing visible to children components via function as children

### DIFF
--- a/src/Action.js
+++ b/src/Action.js
@@ -8,7 +8,7 @@ const contextTypes = {
 }
 
 const propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   hide: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,

--- a/src/State.js
+++ b/src/State.js
@@ -9,7 +9,7 @@ const contextTypes = {
 }
 
 const propTypes = {
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
   value: PropTypes.oneOfType([
     PropTypes.arrayOf(PropTypes.string),
     PropTypes.string,

--- a/src/createConditional.js
+++ b/src/createConditional.js
@@ -45,6 +45,9 @@ export const createConditional = ({
     }
 
     render() {
+      if (typeof this.props.children === 'function') {
+        return this.props.children({ visible: this.state.visible })
+      }
       return this.state.visible ? this.props.children : null
     }
   }


### PR DESCRIPTION
**Problem**
I wanted to animate a state in and out with `Transition` from `react-transition-group`. For that in need to know if `<State />` is rendering the component or not.

**Possible Solution**
Use Function as children pattern to expose `visible` to descendant components. One could also just clone the child and add the prop however that would be quite inflexible and not explicit. In general would you be open to move the lib to a render prop based approach?

**Example**
```js
<State value="questions.askAddress">
  {({ visible }) => (
    <Fade in={visible}>
      <AskAddress
        firstname={this.props.askName.firstname}
        initialState={this.props.askAddress}
        onPrevious={() => transition('PREV_QUESTION')}
        onSubmit={data =>
          transition('NEXT_QUESTION', { askAddress: data })
        }
      />
    </Fade>
  )}
</State>
```

I hope this makes more sense now 😄 .

PS. Of course this is not ment to be merged just a possible starting point