### PR TITLE
Namespace component state

### DIFF
--- a/playground/App.js
+++ b/playground/App.js
@@ -50,7 +50,7 @@ export class App extends React.Component {
         <Action show="enterFetching">Loading...</Action>
         <Action show="enterSuccess">
           <ul>
-            {this.props.gists
+            {this.props.data.gists
               .filter(gist => gist.description)
               .map(gist => <li key={gist.id}>{gist.description}</li>)}
           </ul>

--- a/src/withStatechart.js
+++ b/src/withStatechart.js
@@ -119,7 +119,7 @@ const withStatechart = (statechart, options = {}) => Component => {
       return (
         <Component
           {...this.props}
-          {...this.state.componentState}
+          data={this.state.componentState}
           machineState={this.state.machineState}
           ref={this.handleRef}
           transition={this.handleTransition}

--- a/test/withStateChart.spec.js
+++ b/test/withStateChart.spec.js
@@ -27,17 +27,17 @@ test('state', () => {
   const instance = renderer.getInstance()
   const component = renderer.root.findByType(Component)
 
-  expect(component.props.counter).toBe(0)
+  expect(component.props.data.counter).toBe(0)
 
   instance.handleTransition('EVENT', { counter: 1 })
 
-  expect(component.props.counter).toBe(1)
+  expect(component.props.data.counter).toBe(1)
 
   instance.handleTransition('EVENT', prevState => ({
     counter: prevState.counter + 1,
   }))
 
-  expect(component.props.counter).toBe(2)
+  expect(component.props.data.counter).toBe(2)
 })
 
 test('actions', () => {


### PR DESCRIPTION
**Problem**
I want to persist data on when the user exits certain states using `onExit` guard. Grabbing the relevant data is tedious since I need to specify what I exactly I want.

**Possible Solution**
Namespace the the component state to `data`.

**Usage**
This is how it would look like.
```js
persistData() {
  const { data } = this.props
  window.localStorage.setItem('machine', JSON.stringify(data))
}
```

