### PR TITLE
Use loose mode for babel transform

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -2,10 +2,12 @@ const { BABEL_ENV, NODE_ENV } = process.env
 const cjs = BABEL_ENV === 'cjs' || NODE_ENV === 'test'
 
 module.exports = {
-  presets: [['env', { modules: false }], 'react'],
+  presets: [['env', { modules: false, loose: true }], 'react'],
 
   plugins: [
     cjs && 'transform-es2015-modules-commonjs',
+    // TODO: after upgrading to babel@7:
+    // use `loose` for both class-properties & object-rest-spread
     'transform-class-properties',
     'transform-object-rest-spread',
     'babel-plugin-idx',


### PR DESCRIPTION
IMHO it shouldn't break anything.

Minified+Gzipped sizes
Pre - 2400 bytes
Pre - 2242 bytes

Reduction - 6% 💰 

Tested with:
```sh
npx uglifyjs dist/react-automata.js -cm --toplevel | gzip -c | wc -c
```