### PR TITLE
Put sideEffects: false in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "DISCLAIMER",
     "dist"
   ],
+  "sideEffects": false,
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "rollup -c",


### PR DESCRIPTION
Should allow webpack to drop unused exports created by runtime calls.