### PR TITLE
Annotate top level calls as pure

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -11,5 +11,6 @@ module.exports = {
     'transform-class-properties',
     'transform-object-rest-spread',
     'babel-plugin-idx',
+    'annotate-pure-calls',
   ].filter(Boolean),
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "webpack-dev-server": "^2.11.1"
   },
   "dependencies": {
+    "babel-plugin-annotate-pure-calls": "^0.2.2",
     "invariant": "^2.2.3",
     "minimatch": "^3.0.4",
     "prop-types": "^15.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -598,6 +598,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-annotate-pure-calls@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/babel-plugin-annotate-pure-calls/-/babel-plugin-annotate-pure-calls-0.2.2.tgz#a0d8c27361db4a518d925a7202f8854382b17594"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
@@ -633,6 +639,10 @@ babel-plugin-syntax-async-functions@^6.8.0:
 babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
 
 babel-plugin-syntax-exponentiation-operator@^6.8.0:
   version "6.13.0"


### PR DESCRIPTION
This allows UglifyJS dropping Action and State if they stay unused when doing dead code elimination. Outcome is similar to webpack's `sideEffects: false`, but `sideEffects` are available only in webpack@4. This allows other tools and earlier versions of webpack (when used in combination with UglifyJS ofc) to drop those.