### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ componentWillTransition(event) {
 
 The lifecycle method invoked when a transition has happened and the state is updated.
 It provides the previous state machine, and the event.
-The current `machineState` is available in `this.state`.
+The current `machineState` is available in `this.props`.
 
 ```js
 componentDidTransition(prevStateMachine, event) {


### PR DESCRIPTION
I noticed the read mentions that the current `machineState` is found in the component's state. It is actually found in the component's props.