### PR TITLE
Wrap propTypes with env check - allows to remove them from production…

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -12,5 +12,6 @@ module.exports = {
     'transform-object-rest-spread',
     'babel-plugin-idx',
     'annotate-pure-calls',
+    ['transform-react-remove-prop-types', { mode: 'unsafe-wrap' }],
   ].filter(Boolean),
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "eslint": "^4.18.1",

--- a/src/Action.js
+++ b/src/Action.js
@@ -29,7 +29,7 @@ export const shouldHide = (props, context) =>
 
 export default createConditional({
   displayName,
-  propTypes,
+  propTypes: process.env.NODE_ENV !== 'production' ? propTypes : null,
   shouldShow,
   shouldHide,
 })

--- a/src/State.js
+++ b/src/State.js
@@ -26,7 +26,7 @@ export const shouldHide = (props, context) =>
 
 export default createConditional({
   displayName,
-  propTypes,
+  propTypes: process.env.NODE_ENV !== 'production' ? propTypes : null,
   shouldShow,
   shouldHide,
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,6 +899,10 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-remove-prop-types@^0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.13.tgz#331cfc05099a808238311d78319c27460d481189"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"


### PR DESCRIPTION
… bundles

Minified+Gzipped sizes
Pre - 2305 bytes
Pre - 2233 bytes

Reduction - 3% 💰 

Tested with:
```sh
npx uglifyjs dist/react-automata.js -cm --toplevel | gzip -c | wc -c
```