### PR TITLE
replace minimatch dependency with glob-to-regexp (#52)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
     "webpack-dev-server": "^3.1.4"
   },
   "dependencies": {
+    "glob-to-regexp": "^0.4.0",
     "invariant": "^2.2.4",
-    "minimatch": "^3.0.4",
     "prop-types": "^15.6.1",
     "react-test-renderer": "^16.4.0",
     "xstate": "^3.3.0"

--- a/src/State.js
+++ b/src/State.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import minimatch from 'minimatch'
+import globToRegExp from 'glob-to-regexp'
 import createConditional from './createConditional'
 
 const displayName = 'State'
@@ -15,7 +15,10 @@ const matches = (value, machineState) => {
   const values = Array.isArray(value) ? value : [value]
   const states = Array.isArray(machineState) ? machineState : [machineState]
 
-  return values.some(val => states.some(state => minimatch(state, val)))
+  return values.some(val => {
+    const matcher = globToRegExp(val)
+    return states.some(state => matcher.test(state))
+  })
 }
 
 export const shouldShow = (props, context) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3087,6 +3087,10 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-to-regexp@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.0.tgz#49bd677b1671022bd10921c3788f23cdebf9c7e6"
+
 glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"


### PR DESCRIPTION
This fixes (#52) the react-native problem by replacing minimatch with glob-to-regexp.

It should also shave of some KBs from the package.

I haven't really reviewed glob-to-regexp, but it seems fairly simple and all existing tests are still passing.

While this is a quick fix to be able to use react-automata in react-native without patching minimatch, I'd consider:

- writing an even simpler matcher. Not sure, what kind of globs need to be supported.
- while the values are only translated to a regexp once per call of the matches function, that should probably memoized?
 