### PR TITLE
make is prop required

### DIFF
--- a/src/createConditional.js
+++ b/src/createConditional.js
@@ -66,7 +66,7 @@ const createConditional = (displayName, contextField) => {
     is: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.string),
       PropTypes.string,
-    ]),
+    ]).isRequired,
     render: PropTypes.func,
     onHide: PropTypes.func,
     onShow: PropTypes.func,


### PR DESCRIPTION
After switching to `v4` didn't noticed that `State` and `Action` apis were also changed, now there is one `is` prop. And because right now it's not required, got some strange error `Uncaught TypeError: Expected a string` from `glob-to-regexp` package, which makes no sense. With this change it will be more clear if someone will face the same problem.