### PR TITLE
Remove reduntant config

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,5 @@
       "eslint --fix",
       "git add"
     ]
-  },
-  "jest": {
-    "testURL": "http://localhost"
   }
 }


### PR DESCRIPTION
Since Jest 23.5.0 has now updated the default `testURL` value to `http://localhost`, there's no need to specify the same config again in `package.json`.