### PR TITLE
Fix: Hoist statics from child in `withStateMachine` HOC

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
   },
   "dependencies": {
     "glob-to-regexp": "^0.4.0",
+    "hoist-non-react-statics": "^3.0.1",
     "invariant": "^2.2.4",
     "memoize-one": "^4.0.0",
     "prop-types": "^15.6.1",

--- a/src/withStateMachine.js
+++ b/src/withStateMachine.js
@@ -4,6 +4,7 @@ import memoize from 'memoize-one'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { Machine, State, StateNode } from 'xstate'
+import hoistStatics from 'hoist-non-react-statics'
 import Context from './context'
 import {
   DEFAULT_CHANNEL,
@@ -213,6 +214,8 @@ const withStateMachine = (statechart, options = {}) => Component => {
       )
     }
   }
+
+  hoistStatics(Automata, Component)
 
   return Automata
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3186,6 +3186,12 @@ hoist-non-react-statics@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz#d2ca2dfc19c5a91c5a6615ce8e564ef0347e2a40"
 
+hoist-non-react-statics@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.0.1.tgz#fba3e7df0210eb9447757ca1a7cb607162f0a364"
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -5546,6 +5552,10 @@ react-hot-loader@4.3.4:
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
     shallowequal "^1.0.2"
+
+react-is@^16.3.2:
+  version "16.5.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.5.2.tgz#e2a7b7c3f5d48062eb769fcb123505eb928722e3"
 
 react-is@^16.4.2:
   version "16.4.2"


### PR DESCRIPTION
The `withStateMachine` HOC function returns a component that doesn't inherit its child component's static properties. This becomes a problem when using libraries like React Navigation and others that depend on their users implementing static properties for customization. Here's a link to the React docs about the importance of lifting the static properties when creating a HOC: https://reactjs.org/docs/higher-order-components.html#static-methods-must-be-copied-over. I ran `yarn test`, and the tests seem to pass with these changes.

<img width="322" alt="screen shot 2018-10-01 at 3 24 29 pm" src="https://user-images.githubusercontent.com/12488826/46310724-1f8a8600-c58e-11e8-8574-0cd07c6aced0.png">

Thanks for your time!