### PR TITLE
document upgrading to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,10 @@ test('it works', () => {
 
 You might find the answer to your question [here](FAQ.md).
 
+# Upgrades
+
+The upgrade process is documented [here](UPGRADING.md).
+
 # Inspiration
 
 [Federico](https://twitter.com/gandellinux), for telling me "Hey, I think building UIs using state machines is the future".

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,4 +15,4 @@ The exported higher-order component known as `withStatechart` was renamed to `wi
 
 `Action` and `State` components props were renamed more consistently. The `hide` and `show` prop from `Action` were unified in the new `is` prop. The `value` prop from `State` was renamed to `is` as well. You should change these props in your code accordingly.
 
-The `testStateChart` method  was renamed to `testStateMachine`, and its signature was changed to `Component[, { fixtures, extendedState }]` from `{ statechart[, fixtures][, extendedState] }, Component`. You need to change that accordingly. Please note, that you don't have to pass the statechart to `testStateMachine` directly, instead you should use the from `withStateMachine` enriched component.
+The `testStateChart` method  was renamed to `testStateMachine`, and its signature was changed to `Component[, { fixtures, extendedState }]` from `{ statechart[, fixtures][, extendedState] }, Component`. You need to change that accordingly. Please note that you don't have to pass the statechart to `testStateMachine` directly, the library will automatically extract it from the `withStateMachine` enriched component.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,18 @@
+# Upgrading
+
+## From v3.0.0 to v4.0.0
+
+The update to React Automata version 4 introduces some braking changes, which also requires changes in users' code.
+
+First step is to update React Automata dependency, and add `react-test-renderer` separately, since that was changed to a peer dependency
+```sh
+yarn add react-automata@^4.0.0 react-test-renderer@^16.3
+```
+
+### API changes
+
+The exported higher-order component known as `withStatechart` was renamed to `withStateMachine`. You should replace all occurences of `withStatechart` with `withStateMachine` in your code.
+
+`Action` and `State` components props were renamed more consistently. The `hide` and `show` prop from `Action` were unified in the new `is` prop. The `value` prop from `State` was renamed to `is` as well. You should change these props in your code accordingly.
+
+The `testStateChart` method  was renamed to `testStateMachine`, and its signature was changed to `Component[, { fixtures, extendedState }]` from `{ statechart[, fixtures][, extendedState] }, Component`. You need to change that accordingly. Please note, that you don't have to pass the statechart to `testStateMachine` directly, instead you should use the from `withStateMachine` enriched component.


### PR DESCRIPTION
As suggested in #78 this change documents the upgrade process from v3 to v4.

I added and linked a new file `UPGRADING.md`. Please let me know, if you would prefer that to be written in `README.md` directly or somewhere else. I think this will be better for future expansion, though.

This closes #78